### PR TITLE
fix: footnote のシンボルの Counting symbols を変更

### DIFF
--- a/template/head.typ
+++ b/template/head.typ
@@ -43,7 +43,7 @@
     ..names.map(author => {
       let footnote = footnotes.at(str(author.group));
 
-      [#author.ja#super(str(footnote.index))]
+      [#author.ja#super(numbering("*", footnote.index))]
     }),
   )
   grid(
@@ -52,7 +52,7 @@
     ..affiliations.map(author => {
       let footnote = footnotes.at(str(author.group));
 
-      [#author.ja#super(str(footnote.index))]
+      [#author.ja#super(numbering("*", footnote.index))]
     }),
   )
 


### PR DESCRIPTION
ヘッダー内の著者の上付き文字を, `template` の引数の `dictionary` 内のインデックスを文字列にキャストしたものから, インデックスを元にした `numbering` の [Counting symbols](https://typst.app/docs/reference/model/numbering/#parameters-numbering) で代用し, 注脚の Counting symbols に合わせるために表示形式をアスタリスク → ダガー → … の形にしました.

<img width="971" alt="image" src="https://github.com/user-attachments/assets/ec26cf23-abc6-4a7c-b24a-ec61eeb81088">

<img width="969" alt="image" src="https://github.com/user-attachments/assets/c47dae1a-bb97-433b-9989-7ae87ca22189">
